### PR TITLE
Bug fix: chrome didn't like my cookies

### DIFF
--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -11,7 +11,10 @@ const loginRouter = require("./authentication/login.router")
 
 const app = express();
 
-app.use(cors());
+app.use(cors({
+    origin: "http://localhost:3000",
+    credentials: true
+}));
 app.use(express.json());
 app.use(cookieParser())
 

--- a/back-end/src/authentication/authenticateToken.js
+++ b/back-end/src/authentication/authenticateToken.js
@@ -3,7 +3,6 @@ const jwt = require('jsonwebtoken');
 // This function is to be used when the frontend requests private resources from the backend
 function authenticateToken(req, res, next) {
     const token = req.cookies.token
-    console.log(req.cookies)
 
     if (!token) {
         return res.status(401).json({ message: "Unauthorized" })

--- a/back-end/src/authentication/authenticateToken.js
+++ b/back-end/src/authentication/authenticateToken.js
@@ -3,6 +3,7 @@ const jwt = require('jsonwebtoken');
 // This function is to be used when the frontend requests private resources from the backend
 function authenticateToken(req, res, next) {
     const token = req.cookies.token
+    console.log(req.cookies)
 
     if (!token) {
         return res.status(401).json({ message: "Unauthorized" })

--- a/back-end/src/authentication/login.controller.js
+++ b/back-end/src/authentication/login.controller.js
@@ -30,9 +30,15 @@ async function login(req, res) {
         // Creates an auth token which includes (in encrypted form) the user's id and a key used to unencrypt the token
         const token = jwt.sign({ userId: user.user_id }, process.env.API_SECRET_KEY, { expiresIn: "1h" });
 
+        res.cookie('token', token, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'development', // set to process.env.NODE_ENV === 'production' if in production
+            sameSite: 'lax',
+            maxAge: 3600000 // 1 hour in milliseconds
+        })
 
-        // Sends token and user info back to frontend
-        res.status(200).json({ token: token, user: user });
+        // Sends user info back to frontend
+        res.status(200).json({ user: user });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: "Internal server error" });

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -15,7 +15,6 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "js-cookie": "^3.0.5",
         "mui-image": "^1.0.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -12666,14 +12665,6 @@
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "bin": {
         "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -10,7 +10,6 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "js-cookie": "^3.0.5",
     "mui-image": "^1.0.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/front-end/src/pages/ExampleLoginPage.jsx
+++ b/front-end/src/pages/ExampleLoginPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { userLogin } from "../utils/api";
+import { userLogin, readUserByUsername } from "../utils/api";
 
 export default function ExampleLoginPage() {
     const [credentials, setCredentials] = useState({
@@ -31,11 +31,23 @@ export default function ExampleLoginPage() {
         }
     }
 
+    const handleClick = async () => {
+        console.log(user.username)
+        try {
+            const response = await readUserByUsername(user.username)
+            console.log(response)
+        } catch (err) {
+            console.error(err)
+        }
+    }
+
     function generateElements(user) {
         let output = []
         for (const [key, value] of Object.entries(user)) {
             output.push(<><h3>{key}</h3><p>{value}</p></>)
         }
+
+        output.push(<button onClick={handleClick} >Load User</button>)
 
         return output
     }

--- a/front-end/src/utils/api.js
+++ b/front-end/src/utils/api.js
@@ -1,5 +1,3 @@
-import Cookies from 'js-cookie';
-
 const API_BASE_URL =
     process.env.REACT_APP_API_BASE_URL || "http://localhost:5001"
 

--- a/front-end/src/utils/api.js
+++ b/front-end/src/utils/api.js
@@ -9,7 +9,10 @@ headers.append("Content-Type", "application/json")
 
 async function fetchJson(url, options, onCancel) {
     try {
-        const response = await fetch(url, options)
+        const response = await fetch(url, {
+            ...options,
+            credentials: 'include'
+        })
 
         if (response.status === 204) {
             return null
@@ -50,16 +53,9 @@ export async function userLogin(username, password, signal) {
         signal,
     }
 
-    const { token, user } = await fetchJson(url, options)
-    if (token) {
-        Cookies.set('token', token, {
-            secure: true,
-            httpOnly: true,
-            sameSite: 'lax'
-        })
+    const { user } = await fetchJson(url, options)
 
-        return user
-    }
+    return user
 }
 
 // Returns a single user with the matching userId(number)


### PR DESCRIPTION
Chrome browser (which has tight security) was getting tripped up on the way I was setting a cookie so I reconfigured a few things and it's working fine now as far as I can tell

steps to test:
1. "npm i" in both frontend and backend
2. "npm start" in frontend and backend
3. in browser -> localhost:3000/example-login
4. login with credentials:
  username: jsmith
  password: securepassword
5. click "Load User" button (below the user info that pops up after login)
6. check console for log with user object ({ data: user_id: 1, first_name: ... }) and make sure it didn't log an error like "Unauthorized

I'm aware that react is throwing some warnings because it doesn't like the hasty and incomplete way that I built out that component

Changes:
- moved cookie setting from frontend api to backend login function, now the cookie is being set in response headers from the backend rather than a token being sent to the frontend api and then set into a cookie there
- configured some settings in front-end/src/utils/api.js/fetchJson and back-end/src/app.js/cors
- added a button to ExampleLoginPage for testing purposes
- removed the no longer necessary js-cookie package from frontend (sorry Vanessa it was all for naught...)