### PR TITLE
Login req.body structure, ChatGPT API

### DIFF
--- a/back-end/package.json
+++ b/back-end/package.json
@@ -25,6 +25,7 @@
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "node": "^20.13.1",
+        "openai": "^4.47.1",
         "pg": "^8.11.5"
     },
     "devDependencies": {

--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -1,6 +1,5 @@
 const path = require("path");
 require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
-const bodyParser = require('body-parser');
 
 const cookieParser = require("cookie-parser");
 const express = require("express");
@@ -19,7 +18,6 @@ app.use(
     })
 );
 app.use(express.json());
-app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 app.get('/', (req, res) => {

--- a/back-end/src/authentication/login.controller.js
+++ b/back-end/src/authentication/login.controller.js
@@ -13,7 +13,7 @@ const service = require("../users/users.service");
 */
 async function login(req, res) {
     try {
-        const { username, password } = req.body;
+        const { username, password } = req.body.data;
 
         const user = await service.readUserByUsername(username);
         if (!user) {

--- a/back-end/src/gpt/gpt.service.js
+++ b/back-end/src/gpt/gpt.service.js
@@ -1,0 +1,7 @@
+const gpt = require("./gptPrompt")
+
+// prompt is just a string like you would type in when you're chatting in the browser
+function sendPrompt(prompt) {
+    gpt(prompt)
+    .then((returned) => console.log(returned))
+}

--- a/back-end/src/gpt/gptPrompt.js
+++ b/back-end/src/gpt/gptPrompt.js
@@ -1,0 +1,19 @@
+const { OpenAI } = require('openai');
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, "..", "..", ".env") });
+const { OPENAI_API_KEY } = process.env;
+
+const openai = new OpenAI({
+  apiKey: OPENAI_API_KEY,
+});
+
+async function gpt(prompt) {
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: "user", content: prompt }],
+    model: "gpt-3.5-turbo",
+  });
+
+  return completion.choices[0].message.content
+}
+
+module.exports = gpt

--- a/back-end/src/index.html
+++ b/back-end/src/index.html
@@ -1,15 +1,49 @@
+<!-- index.html -->
+<!DOCTYPE html>
 <html>
-<head>
-  <title>Login</title>
-</head>
-<body>
-  <h2>Login Form</h2>
-  <form action="/login" method="post">
-    <label for="username">Username:</label><br>
-    <input type="text" id="username" name="username"><br>
-    <label for="password">Password:</label><br>
-    <input type="password" id="password" name="password"><br><br>
-    <input type="submit" value="Login">
-  </form>
-</body>
+    <head>
+        <title>Login</title>
+    </head>
+    <body>
+        <h2>Login Form</h2>
+        <form id="loginForm" action="/login" method="post">
+            <input type="hidden" name="data" />
+            <label for="username">Username:</label><br />
+            <input type="text" id="username" name="username" /><br />
+            <label for="password">Password:</label><br />
+            <input type="password" id="password" name="password" /><br /><br />
+            <input type="submit" value="Login" />
+        </form>
+
+        <script>
+            const form = document.querySelector("#loginForm");
+
+            // Take over form submission
+            form.addEventListener("submit", async (event) => {
+                event.preventDefault();
+                const headers = new Headers();
+                headers.append("Content-Type", "application/json");
+
+                const username = document.getElementById("username").value;
+                const password = document.getElementById("password").value;
+
+                const formData = {
+                    data: { username: username, password: password },
+                };
+
+                try {
+                    const response = await fetch("/login", {
+                        method: "POST",
+                        headers,
+                        body: JSON.stringify(formData),
+                    });
+                    if (response.ok) {
+                        console.log("Logged in!")
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            });
+        </script>
+    </body>
 </html>

--- a/back-end/src/users/users.router.js
+++ b/back-end/src/users/users.router.js
@@ -14,6 +14,7 @@ router
     .route("/:username")
     .get(usersController.read)
     .put(usersController.update)
+    .patch(usersController.patch)
     .delete(usersController.deleteUser)
     .all(methodNotAllowed);
 

--- a/back-end/src/users/users.service.js
+++ b/back-end/src/users/users.service.js
@@ -25,6 +25,12 @@ function update(updatedUser) {
         .update(updatedUser, "*");
 }
 
+function patch(patchedUser) {
+    return knex("users")
+        .where({ user_id: patchedUser.user_id})
+        .update(patchedUser, "*");
+}
+
 async function deleteUser(user_id) {
     try {
         await knex.transaction(async (trx) => {
@@ -44,5 +50,6 @@ module.exports = {
     readUser,
     readUserByUsername,
     update,
+    patch,
     deleteUser,
 };

--- a/front-end/src/utils/api.js
+++ b/front-end/src/utils/api.js
@@ -46,7 +46,7 @@ export async function userLogin(username, password, signal) {
     const options = {
         method: "POST",
         headers,
-        body: JSON.stringify({ username: username, password: password }),
+        body: JSON.stringify({ data: { username: username, password: password } }),
         signal,
     };
 

--- a/front-end/src/utils/api.js
+++ b/front-end/src/utils/api.js
@@ -174,3 +174,18 @@ export async function deleteUser(username, signal) {
 
     return await fetchJson(url, options);
 }
+
+// Allows user data to be updated by only sending one (or more) property, rather than an entire user object
+// Acceptable properties: "first_name", "last_name", "username", "email", "age", "occupation, img_src"
+// patch arg should look like { age: 30 } or { occupation: "president", email: "potus@whitehouse.gov"}
+export async function patchUser(username, patch, signal) {
+    const url = `${API_BASE_URL}/users/${username}`
+    const options = {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify(patch),
+        signal
+    }
+
+    return await fetchJson(url, options);
+}


### PR DESCRIPTION
Pretty small pull request for having been at it all day with this but here's where I'm at.

Steps:
- Run "npm i" in backend, I installed an openai package
- Configure env variable for OPENAI_API_KEY (I'll send it over). The dotenv path in gpt/gptPrompt.js might need adjusted but I think I got it right
- Try out the api! In gpt.service, under the sendPrompt function, add a call (sendPrompt("tell me something nice") and run the file with "node gpt.service.js" or whatever the path is to that file from where your terminal is at the moment
- I put in like 20 or 30 short prompts and they charged me $0.01 so take it easy lol

Changes:
- Updated login request body structure to the { data: { username, password } } format instead of the { username, password } format
- Tweaked the index.html server login page to send credentials with the { data: { username, password }} structure
- Added PATCH user functionality from frontend api.js all the way down to users.service, with validations
- Added chatgpt api functions in back-end/src/gpt