### PR TITLE
patch (aka update) and delete api routes for user goals completed

### DIFF
--- a/back-end/src/goals/goals.service.js
+++ b/back-end/src/goals/goals.service.js
@@ -28,8 +28,24 @@ function read(goalId, userId) {
         .first();
 }
 
+// Update goal
+function update(updatedGoal) {
+    return knex("goals")
+        .select("*")
+        .where({ goal_id: updatedGoal.goal_id })
+        .update(updatedGoal, "*")
+        .then((updatedRecords) => updatedRecords[0]);
+}
+
+// Delete goal
+function destroy(goalId) {
+    return knex("goals").where({ goal_id: goalId }).del();
+}
+
 module.exports = {
     list,
     create,
     read,
+    update,
+    destroy,
 };

--- a/back-end/src/users/users.router.js
+++ b/back-end/src/users/users.router.js
@@ -28,6 +28,8 @@ router
 router
     .route("/:userId/goals/:goalId")
     .get(goalsController.read)
+    .patch(goalsController.update)
+    .delete(goalsController.destroy)
     .all(methodNotAllowed);
 
 module.exports = router;


### PR DESCRIPTION
Changes:
- added some error handling (not finished though)
- user goals can now be updated and deleted, at least from the backend

I've written frontend api requests in the api.js on my local but don't want to push the changes yet because I haven't tested them.

